### PR TITLE
app-services: Fix duplicate "js" id for LS2

### DIFF
--- a/com.palm.service.accounts/files/sysbus/com.palm.service.accounts.role.json
+++ b/com.palm.service.accounts/files/sysbus/com.palm.service.accounts.role.json
@@ -1,7 +1,7 @@
 {
+	"appId": "com.palm.service.accounts",
 	"allowedNames": ["com.palm.service.accounts"],
 	"type": "regular",
-	"exeName": "js",
 	"permissions": [{
 		"service": "com.palm.service.accounts",
 		"inbound": ["*"],

--- a/com.palm.service.calendar.reminders/files/sysbus/com.palm.service.calendar.reminders.role.json
+++ b/com.palm.service.calendar.reminders/files/sysbus/com.palm.service.calendar.reminders.role.json
@@ -1,7 +1,7 @@
 {
+	"appId": "com.palm.service.calendar.reminders",
 	"allowedNames": ["com.palm.service.calendar.reminders"],
 	"type": "regular",
-	"exeName": "js",
 	"permissions": [{
 		"service": "com.palm.service.calendar.reminders",
 		"inbound": ["*"],

--- a/com.palm.service.contacts.linker/files/sysbus/com.palm.service.contacts.linker.role.json
+++ b/com.palm.service.contacts.linker/files/sysbus/com.palm.service.contacts.linker.role.json
@@ -1,7 +1,7 @@
 {
+	"appId": "com.palm.service.contacts.linker",
 	"allowedNames": ["com.palm.service.contacts.linker"],
 	"type": "regular",
-	"exeName": "js",
 	"permissions": [{
 		"service": "com.palm.service.contacts.linker",
 		"inbound": ["*"],

--- a/com.palm.service.contacts/files/sysbus/com.palm.service.contacts.role.json
+++ b/com.palm.service.contacts/files/sysbus/com.palm.service.contacts.role.json
@@ -1,7 +1,7 @@
 {
+	"appId": "com.palm.service.contacts",
 	"allowedNames": ["com.palm.service.contacts"],
 	"type": "regular",
-	"exeName": "js",
 	"permissions": [{
 		"service": "com.palm.service.contacts",
 		"inbound": ["*"],


### PR DESCRIPTION
"exeName": "js" is no longer required for LS2 in webOS OSE, and will lead to the following error:

Dec  6 09:02:38 qemux86-64 user.warn ls-hubd: [] [pmlog] ls-hubd LSHUB_ROLE_EXISTS {} Role already exists for id: "js"

This has been addressed by giving (NodeJS) services an appId it seems, so following that practice as well for our own NodeJS services.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>